### PR TITLE
Fix: POST/PUT/PATCH requests not sending body

### DIFF
--- a/src/main/java/com/akash/embedqa/service/impl/ApiExecutorServiceImpl.java
+++ b/src/main/java/com/akash/embedqa/service/impl/ApiExecutorServiceImpl.java
@@ -88,7 +88,7 @@ public class ApiExecutorServiceImpl implements ApiExecutorService {
             addAuthentication(httpRequest, request.getAuthType(), request.getAuthConfig(), variables);
 
             // Add body for methods that support it
-            if (hasBody(request.getMethod().name()) && request.getBody() != null) {
+            if (request.getMethod().supportsBody() && request.getBody() != null) {
                 addBody(httpRequest, request.getBody(), request.getBodyType(), variables);
             }
 
@@ -170,10 +170,6 @@ public class ApiExecutorServiceImpl implements ApiExecutorService {
         }
 
         return AppConstant.HTTP + trimmedUrl;
-    }
-
-    private boolean hasBody(String method) {
-        return Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH).contains(method.toUpperCase());
     }
 
     private void addHeaders(HttpUriRequestBase request, List<KeyValuePairDTO> headers,


### PR DESCRIPTION
## Summary
Fixed the bug where POST, PUT, and PATCH requests were not sending the request body.

## Root Cause
The `hasBody()` method was comparing a `String` with `HttpMethod` enum values:
```java
private boolean hasBody(String method) {
    return Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH).contains(method.toUpperCase());
}
```

`Set<HttpMethod>` cannot contain a `String`, so this always returned `false`.

## Solution
Replaced with the existing `supportsBody()` method from the `HttpMethod` enum:
```java
// Before
if (hasBody(request.getMethod().name()) && request.getBody() != null)

// After  
if (request.getMethod().supportsBody() && request.getBody() != null)
```

## Changes
- `ApiExecutorServiceImpl.java`: Use `supportsBody()` instead of `hasBody()`
- Removed unused `hasBody()` method

## Testing
- [x] POST request with JSON body works
- [x] PUT request with body works
- [x] PATCH request with body works
- [x] GET request still works (no body)

Fixes #7 