### PR TITLE
Feature: Add backend support to handle Form Data body type when execu…

### DIFF
--- a/src/main/java/com/akash/embedqa/model/dtos/request/ExecuteRequestDTO.java
+++ b/src/main/java/com/akash/embedqa/model/dtos/request/ExecuteRequestDTO.java
@@ -38,6 +38,10 @@ public class ExecuteRequestDTO {
     @Builder.Default
     private List<KeyValuePairDTO> queryParams = new ArrayList<>();
 
+    @Valid
+    @Builder.Default
+    private List<KeyValuePairDTO> formData = new ArrayList<>();
+
     private String body;
 
     @Builder.Default


### PR DESCRIPTION
## Description
Add backend support to handle Form Data body type when executing API requests. The API executor should send form data as `application/x-www-form-urlencoded` content type.

## Requirements Done
- [x] Accept `formData` field in ExecuteRequestDTO
- [x] Convert form data key-value pairs to URL encoded format
- [x] Set correct Content-Type header (`application/x-www-form-urlencoded`)
- [x] Support environment variable resolution in form data fields



### ApiExecutorServiceImpl.java
- Update `addBody()` method to check for FORM_DATA type
- Add `addFormDataBody()` method to handle form encoding
- Use `UrlEncodedFormEntity` for form data

## Labels
`enhancement`, `backend`

Fixes #9